### PR TITLE
fix: default boilerplate to Studio Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The frontend uses published `@genlayer/transaction-kit` and
 `@genlayer/transaction-kit-react` version `0.1.0-rc.2`, with `genlayer-js`
 `2.0.0-rc.1`. Run `npm ci` from the repository root to install the locked releases.
 
-The default network is the Consensus v0.6 preview at
-`https://studio-dev.genlayer.com/api` (chain ID `61997`). Copy
+The default network is Studio Next (Consensus v0.6) at
+`https://studio-next.genlayer.com/api` (chain ID `61997`). Copy
 `frontend/.env.example`; change the RPC URL and chain ID together when targeting
 another deployment. Wallet, SDK, and Transaction Kit share this configuration.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,11 +1,11 @@
 # GenLayer RPC API URL
-# The v2 prerelease defaults to the hosted Consensus v0.6 preview.
+# The v2 prerelease defaults to the hosted Studio Next (Consensus v0.6).
 # Override all network values together when using another GenLayer deployment.
-NEXT_PUBLIC_GENLAYER_RPC_URL=https://studio-dev.genlayer.com/api
+NEXT_PUBLIC_GENLAYER_RPC_URL=https://studio-next.genlayer.com/api
 
 # GenLayer Network Configuration
 NEXT_PUBLIC_GENLAYER_CHAIN_ID=61997
-NEXT_PUBLIC_GENLAYER_CHAIN_NAME=GenLayer Studio Devnet
+NEXT_PUBLIC_GENLAYER_CHAIN_NAME=GenLayer Studio Next
 NEXT_PUBLIC_GENLAYER_SYMBOL=GEN
 
 # GenLayer Football Betting Contract Address

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,7 @@ cp .env.example .env
 
 3. Configure environment variables:
    - `NEXT_PUBLIC_CONTRACT_ADDRESS` - GenLayer Football Betting contract address
-   - `NEXT_PUBLIC_GENLAYER_RPC_URL` - GenLayer RPC URL (defaults to `https://studio-dev.genlayer.com/api`)
+   - `NEXT_PUBLIC_GENLAYER_RPC_URL` - GenLayer RPC URL (defaults to `https://studio-next.genlayer.com/api`)
    - `NEXT_PUBLIC_GENLAYER_CHAIN_ID` - RPC chain ID (defaults to `61997`)
    - `NEXT_PUBLIC_GENLAYER_CHAIN_NAME` - Network label shown to users
 

--- a/frontend/__tests__/network-config.test.ts
+++ b/frontend/__tests__/network-config.test.ts
@@ -9,11 +9,11 @@ import {
 } from "../lib/genlayer/network";
 
 describe("GenLayer network configuration", () => {
-  it("defaults every consumer to the Studio v0.6 preview", () => {
+  it("defaults every consumer to Studio Next", () => {
     expect(GENLAYER_CHAIN).toMatchObject({
       id: studioDevnet.id,
-      name: studioDevnet.name,
-      rpcUrls: studioDevnet.rpcUrls,
+      name: "GenLayer Studio Next",
+      rpcUrls: { default: { http: ["https://studio-next.genlayer.com/api"] } },
     });
     expect(GENLAYER_CHAIN_ID).toBe(studioDevnet.id);
     expect(GENLAYER_CHAIN_ID_HEX).toBe(`0x${studioDevnet.id.toString(16).toUpperCase()}`);

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -78,7 +78,7 @@ export default function HomePage() {
                 Powered by GenLayer
               </a>
               <a
-                href="https://studio.genlayer.com"
+                href="https://studio-next.genlayer.com"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:text-accent transition-colors"

--- a/frontend/lib/genlayer/network.ts
+++ b/frontend/lib/genlayer/network.ts
@@ -1,6 +1,9 @@
 import { studioDevnet } from "genlayer-js/chains";
 
-const DEFAULT_RPC_URL = studioDevnet.rpcUrls.default.http[0];
+// The released SDK has no Studio Next preset yet. Preserve its Consensus v0.6
+// configuration while selecting the developer-facing Studio Next deployment.
+const DEFAULT_RPC_URL = "https://studio-next.genlayer.com/api";
+const DEFAULT_CHAIN_NAME = "GenLayer Studio Next";
 
 export interface GenLayerNetworkOverrides {
   chainId?: string;
@@ -31,7 +34,7 @@ export function createGenLayerNetworkConfig(
   overrides: GenLayerNetworkOverrides = {},
 ) {
   const chainId = parseChainId(overrides.chainId);
-  const chainName = overrides.chainName || studioDevnet.name;
+  const chainName = overrides.chainName || DEFAULT_CHAIN_NAME;
   const rpcUrl = overrides.rpcUrl || DEFAULT_RPC_URL;
   const symbol = overrides.symbol || "GEN";
 


### PR DESCRIPTION
## Delivery context
Small follow-up to merged #90 on `v2-dev` at `69964064ce18592dcd004f209c7bb4122b6359e8`. No cross-repository dependency or sibling composition required.

## Problem and outcome
Developer-facing boilerplate should default to Studio Next, not Studio Devnet. Use `https://studio-next.genlayer.com/api` and wallet label `GenLayer Studio Next`; retain verified chain ID 61997 and the released SDK's Consensus v0.6 configuration. No SDK Next preset exists in the pinned release.

## Implementation and validation
Align shared wallet/SDK/kit defaults, environment example, setup documentation, Studio navigation link, and regression test. No dependency or contract changes.

Passed: TypeScript, all 17 tests, production build, diff check. Read-only Studio Next `eth_chainId` returned `0xf22d` (61997). Full E2E is not requested for this configuration-only integration follow-up; stable promotion remains separately gated. Rollback: revert this PR.